### PR TITLE
Update RowSorter.js

### DIFF
--- a/src/RowSorter.js
+++ b/src/RowSorter.js
@@ -488,7 +488,7 @@
     function is(obj, tag)
     {
         return obj && typeof obj === 'object' &&
-            'nodeName' in obj && obj.nodeName === tag.toUpperCase();
+            'nodeName' in obj && obj.nodeName.toUpperCase() === tag.toUpperCase();
     }
 
     /**


### PR DESCRIPTION
The nodeName might be lowercase, this fixes the "Table not found" error.